### PR TITLE
Github URL returns a 404

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 setup(
     name='sphinxcontrib-images',
     version='0.4.0',
-    url='http://spinus.github.com/sphinxcontrib-images',
+    url='https://github.com/spinus/sphinxcontrib-images',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-images',
     license='Apache 2',
     author='Tomasz Czyż',


### PR DESCRIPTION
See "Home Page" here: https://pypi.python.org/pypi/sphinxcontrib-images
