### PR TITLE
Fix to accept images from the docs app

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -156,12 +156,15 @@ class ImageDirective(Directive):
     def is_remote(self, uri):
         uri = uri.strip()
         env = self.state.document.settings.env
+        app_directory = os.path.dirname(os.path.abspath(self.state.document.settings._source))
 
         if uri.startswith('/'):
             return False
         if uri.startswith('file://'):
             return False
         if os.path.isfile(os.path.join(env.srcdir, uri)):
+            return False
+        if os.path.isfile(os.path.join(app_directory, uri)):
             return False
         if '://' in uri:
             return True


### PR DESCRIPTION
I have the following image working code in my docs app called catalogue:

    .. image:: images/product_attrbutes.png
but trying to use is a thumbnail:

    .. thumbnail:: images/product_attrbutes.png

doesn't work.

ValueError: Image URI `catalogue/images/product_attrbutes.png` have to be local relative or absolute path to image, or remote address.