### PR TITLE
Added lightbox.min.map to the manifest and static files to prevent a 404

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include sphinxcontrib_images_lightbox2/lightbox2/img/loading.gif
 include sphinxcontrib_images_lightbox2/lightbox2/img/next.png
 include sphinxcontrib_images_lightbox2/lightbox2/img/prev.png
 include sphinxcontrib_images_lightbox2/lightbox2/js/lightbox.min.js
+include sphinxcontrib_images_lightbox2/lightbox2/js/lightbox.min.map
 include sphinxcontrib_images_lightbox2/lightbox2/js/jquery-1.11.0.min.js
 include sphinxcontrib_images_lightbox2/lightbox2/css/screen.css
 include sphinxcontrib_images_lightbox2/lightbox2/css/lightbox.css

--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -7,6 +7,7 @@ class LightBox2(images.Backend):
         'lightbox2/css/lightbox.css',
         'lightbox2/js/jquery-1.11.0.min.js',
         'lightbox2/js/lightbox.min.js',
+        'lightbox2/js/lightbox.min.map',
         'lightbox2/img/close.png',
         'lightbox2/img/next.png',
         'lightbox2/img/prev.png',


### PR DESCRIPTION
Whenever sphinxcontrib-images is included, each page views will trigger a 404 because the source map was omitted. Rather than modifying lightbox2 to remove the source map, I added it to sphinxcontrib-images.