### PR TITLE
Default support for builders other than HTML

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -301,7 +301,10 @@ def configure_backend(app):
             def inner_wrapper(writer, node):
                 return f(writer, node)
             return inner_wrapper
-        signature = '_{}_{}'.format(node.__name__, output_type)
+        if output_type == 'html':
+            signature = '_{}_{}'.format(node.__name__, output_type)
+        else:
+            signature = '_{}'.format(node.__name__)
         return (backend_method(getattr(backend, 'visit' + signature,
                                        not_supported)),
                 backend_method(getattr(backend, 'depart' + signature,

--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -50,3 +50,8 @@ class LightBox2(images.Backend):
     def depart_image_node_html(self, writer, node):
         writer.body.append('</a>')
 
+    def visit_image_node(self, writer, node):
+        writer.visit_image(node)
+
+    def depart_image_node(self, writer, node):
+        writer.depart_image(node)


### PR DESCRIPTION
This is a basic idea to get other builder to simply forward the thumbnail directive.