### PR TITLE
add arguments show_caption & legacy_class

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -215,6 +215,27 @@ All available arguments:
 
         to fix document flow.
 
+:show_caption: (default: ``False``)
+
+    Show the title as a caption below the image.
+    
+    .. warning::
+    
+        Enabling the caption nests the clickable image inside an HTML ``figure``
+        which gets the class if defined.
+        
+        This mays break existing styles.
+        
+        To solve styles compatibility issues, you may use the *legacy_class* argument.
+
+:legacy_class:
+
+    Only applicable when *show_caption* is ``True``.
+    
+    The classese specified are added to the clickable image.
+    
+    The ``figure`` HTML element still gets the classes specified by the *class* argument.
+
 Examples
 --------
 
@@ -323,6 +344,13 @@ Aligning
    .. thumbnail:: img.jpg
       :align: right
 
+
+Caption
+-------
+
+.. thumbnail:: img.jpg
+   :title: Some nice title to the picture
+   :show_caption: True
 
 
 

--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 __author__ = 'Tomasz Czyż <tomaszczyz@gmail.com>'
 __license__ = "Apache 2"
 
@@ -45,7 +45,7 @@ DEFAULT_CONFIG = dict(
     requests_kwargs={},
     cache_path='_images',
     override_image_directive=False,
-    caption=False,
+    show_caption=False,
 )
 
 
@@ -110,7 +110,8 @@ class ImageDirective(Directive):
         'download': directive_boolean,
         'title': directives.unchanged,
         'align': align,
-        'caption': directive_boolean,
+        'show_caption': directive_boolean,
+        'legacy_class': directives.class_option,
     }
 
     def run(self):
@@ -126,7 +127,8 @@ class ImageDirective(Directive):
         alt = self.options.get('alt', '')
         title = self.options.get('title', '' if conf['default_show_title'] else None)
         align = self.options.get('align', '')
-        caption = self.options.get('caption', False)
+        show_caption = self.options.get('show_caption', False)
+        legacy_classes = self.options.get('legacy_class', '')
 
         #TODO get default from config
         download = self.options.get('download', conf['download'])
@@ -167,7 +169,8 @@ class ImageDirective(Directive):
             img['title'] = img['content']
             img['content'] = ''
 
-        img['caption'] = caption
+        img['show_caption'] = show_caption
+        img['legacy_classes'] = legacy_classes
         img['group'] = group
         img['size'] = (width, height)
         img['classes'] += classes

--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -45,6 +45,7 @@ DEFAULT_CONFIG = dict(
     requests_kwargs={},
     cache_path='_images',
     override_image_directive=False,
+    caption=False,
 )
 
 
@@ -109,6 +110,7 @@ class ImageDirective(Directive):
         'download': directive_boolean,
         'title': directives.unchanged,
         'align': align,
+        'caption': directive_boolean,
     }
 
     def run(self):
@@ -124,6 +126,7 @@ class ImageDirective(Directive):
         alt = self.options.get('alt', '')
         title = self.options.get('title', '' if conf['default_show_title'] else None)
         align = self.options.get('align', '')
+        caption = self.options.get('caption', False)
 
         #TODO get default from config
         download = self.options.get('download', conf['download'])
@@ -164,6 +167,7 @@ class ImageDirective(Directive):
             img['title'] = img['content']
             img['content'] = ''
 
+        img['caption'] = caption
         img['group'] = group
         img['size'] = (width, height)
         img['classes'] += classes

--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -22,19 +22,25 @@ class LightBox2(images.Backend):
             node['uri'] = os.path.join(builder.imgpath,
                                        builder.images[node['uri']])
 
-        writer.body.append(
+        if node['show_caption'] is True:
+            writer.body.append(
             u'''<figure class="{cls}">
-                <a data-lightbox="{group}"
-                   href="{href}"
-                   class="{cls}"
-                   title="{title}"
-                   data-title="{title}"
-                   >'''.format(
-                group='group-%s' % node['group'] if node['group'] else node['uri'],
-                href=node['uri'],
-                cls=' '.join(node['classes']),
-                title=node['title'] + node['content'],
-                ))
+            '''.format(cls=' '.join(node['classes']),))
+        if node['show_caption'] is True and node['legacy_classes']:
+            writer.body.append(
+            u'''<a class="{legcls}"'''.format(legcls=' '.join(node['legacy_classes']),))
+        else:
+            writer.body.append(u'''<a class="{cls}"'''.format(cls=' '.join(node['classes']),))
+        writer.body.append(
+            u'''
+               data-lightbox="{group}"
+               href="{href}"
+               title="{title}"
+               data-title="{title}"
+               >'''.format( group='group-%s' % node['group'] if node['group'] else node['uri'],
+                            href=node['uri'],
+                            title=node['title'] + node['content'],
+                            ))
         writer.body.append(
             '''<img src="{src}"
                     class="{cls}"
@@ -51,6 +57,6 @@ class LightBox2(images.Backend):
 
     def depart_image_node_html(self, writer, node):
         writer.body.append('</a>')
-        if node['caption'] is True:
-            writer.body.append(u'''<figcaption class="{cls}">{title}</figcaption>'''.format(cls=' '.join(node['classes']),title=node['title'],))
-        writer.body.append('</figure>')
+        if node['show_caption'] is True:
+            writer.body.append(u'''<figcaption>{title}</figcaption>'''.format(title=node['title'],))
+            writer.body.append('</figure>')

--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -26,9 +26,11 @@ class LightBox2(images.Backend):
             writer.body.append(
             u'''<figure class="{cls}">
             '''.format(cls=' '.join(node['classes']),))
-        if node['show_caption'] is True and node['legacy_classes']:
-            writer.body.append(
-            u'''<a class="{legcls}"'''.format(legcls=' '.join(node['legacy_classes']),))
+            if node['legacy_classes']:
+                writer.body.append(
+                u'''<a class="{legcls}"'''.format(legcls=' '.join(node['legacy_classes']),))
+            else:
+                writer.body.append(u'''<a ''')
         else:
             writer.body.append(u'''<a class="{cls}"'''.format(cls=' '.join(node['classes']),))
         writer.body.append(
@@ -43,20 +45,21 @@ class LightBox2(images.Backend):
                             ))
         writer.body.append(
             '''<img src="{src}"
-                    class="{cls}"
-                    width="{width}"
-                    height="{height}"
-                    alt="{alt}"/>
-                    '''.format(src=node['uri'],
-                               cls='align-%s' % node['align'] if node['align'] else '',
-                               width=node['size'][0],
-                               height=node['size'][1],
-                               alt=node['alt'],
-                               title=node['title']))
+                     class="{cls}"
+                     width="{width}"
+                     height="{height}"
+                     alt="{alt}"/>
+                '''.format(src=node['uri'],
+                           cls='align-%s' % node['align'] if node['align'] else '',
+                           width=node['size'][0],
+                           height=node['size'][1],
+                           alt=node['alt'],
+                           title=node['title']))
 
 
     def depart_image_node_html(self, writer, node):
         writer.body.append('</a>')
         if node['show_caption'] is True:
-            writer.body.append(u'''<figcaption>{title}</figcaption>'''.format(title=node['title'],))
+            writer.body.append(u'''<figcaption>{title}</figcaption>
+            '''.format(title=node['title'],))
             writer.body.append('</figure>')

--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -23,7 +23,8 @@ class LightBox2(images.Backend):
                                        builder.images[node['uri']])
 
         writer.body.append(
-            u'''<a data-lightbox="{group}"
+            u'''<figure class="{cls}">
+                <a data-lightbox="{group}"
                    href="{href}"
                    class="{cls}"
                    title="{title}"
@@ -50,3 +51,6 @@ class LightBox2(images.Backend):
 
     def depart_image_node_html(self, writer, node):
         writer.body.append('</a>')
+        if node['caption'] is True:
+            writer.body.append(u'''<figcaption class="{cls}">{title}</figcaption>'''.format(cls=' '.join(node['classes']),title=node['title'],))
+        writer.body.append('</figure>')


### PR DESCRIPTION
As discussed I've renamed the ``caption`` argument into ``show_caption``.

When the captions is shown, only the ``<figure>`` gets the defined ``class``, but it's now possible to force the ``<a>`` element to have a class, by using the ``legacy_class`` argument.
I think it's enough to solve the possible breaks of styling.