### PR TITLE
use url-compatible slashes to join the URI parts

### DIFF
--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -19,8 +19,8 @@ class LightBox2(images.Backend):
         # make links local (for local images only)
         builder = self._app.builder
         if node['uri'] in builder.images:
-            node['uri'] = os.path.join(builder.imgpath,
-                                       builder.images[node['uri']])
+            node['uri'] = '/'.join([builder.imgpath,
+                                    builder.images[node['uri']]])
 
         if node['show_caption'] is True:
             writer.body.append(


### PR DESCRIPTION
Instead of os.path.join, use '/'. string join to put the URI together