### PR TITLE
Remove unused import for Sphinx 1.6 compatibility (fixes #41)

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -21,7 +21,6 @@ from sphinx.locale import _
 from sphinx.environment import NoUri
 from sphinx.util.osutil import copyfile
 from sphinx.util.compat import Directive
-from sphinx.util.compat import make_admonition
 from sphinx.util.console import brown
 from sphinx.util.osutil import ensuredir
 


### PR DESCRIPTION
Removing this call makes things compatible with Sphinx 1.6 (fixes issue #41)