### PR TITLE
Fix OSX compat error

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -21,10 +21,12 @@ from sphinx.locale import _
 from sphinx.environment import NoUri
 from sphinx.util.osutil import copyfile
 from sphinx.util.compat import Directive
-from sphinx.util.compat import make_admonition
 from sphinx.util.console import brown
 from sphinx.util.osutil import ensuredir
-
+try:
+    from sphinx.util.compat import make_admonition
+except ImportError:
+    from docutils.parsers.rst.directives.admonitions import BaseAdmonition as make_admonition
 from docutils import nodes, utils
 from docutils.parsers.rst import roles
 from docutils.parsers.rst import directives
@@ -333,7 +335,6 @@ def setup(app):
     app.connect('builder-inited', configure_backend)
     app.connect('env-updated', download_images)
     app.connect('env-updated', install_backend_static_files)
-    return {'version': sphinx.__version__, 'parallel_read_safe': True}
 
 
 def main(args=sys.argv[1:]):


### PR DESCRIPTION
/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/sphinxcontrib/images.py:23: RemovedInSphinx17Warning: sphinx.util.compat.Directive is deprecated and will be removed in Sphinx 1.7, please use the standard library version instead.
  from sphinx.util.compat import Directive

Extension error:
Could not import extension sphinxcontrib.images (exception: cannot import name 'make_admonition')
make: *** [html] Error 1